### PR TITLE
Add information about environment variables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ A Linux host environment (e.g. Ubuntu or similar variant) with:
 * [Docker](https://docs.docker.com/desktop/install/linux-install/)
 * [Visual Studio Code](https://code.visualstudio.com/) with the
   [Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)
+* The following environment variables set:
+```bash
+$> export CTRUSER=...   # "vscode", for example
+$> export CTRUID=...    # "1000", for example
+$> export CTRGID=...    # "1000", for example
+$> export USER=...      # "jdoe", for example
+$> export HOME=...      # "/home/jdoe", for example
+$> export DISPLAY=...   # "127.0.0.1:0.0", for example
+```
 
 ### Building The Dev Container
 


### PR DESCRIPTION
The `devcontainer.json` file expects the variables `CTRUSER`, `CTRUID`, `CTRGID`, `USER`, `HOME`, and `DISPLAY` to be defined in the host environment. If they are not, then the dev container fails to build and the error is not immediately apparent. If someone isn't used to debugging dev containers, this could be a mistake that would trip them up for a couple of hours since it's not exactly transparent what the dev container is doing in the  Docker build logs.

Hope that helps! This is also the first PR I've ever attempted through a fork, so go easy on me ;)